### PR TITLE
instance.destroy() throws an error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,7 @@ module.exports = function CommentPlugin( sequelizeDialect, settings ) {
 				var baseFragment = originalGeneratorMethod.apply( this, arguments );
 				var options = arguments[ method.optionsArgument ];
 
-				var fragment = options.comment
+				var fragment = options && options.comment
 					? prependComment( options.comment, getDelimiter( settings ), baseFragment )
 					: baseFragment
 				;


### PR DESCRIPTION
internalError { TypeError: Cannot read property 'comment' of null
    at Object.proxyMethod (./sequelize-comment/lib/index.js:76:27)

better to silently ignore than throw an error.

Also it seems that a comment in instance.destroy() does not make it to the proxyMethod(). Is that the case for all instance methods?
